### PR TITLE
Missed synchronization 

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/System/Net/InternalException.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/System/Net/InternalException.cs
@@ -2,13 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.Serialization;
+
 namespace System.Net
 {
+    [Serializable]
     internal class InternalException : Exception
     {
-        internal InternalException()
+        public InternalException() : this("InternalException thrown.")
         {
-            NetEventSource.Fail(this, "InternalException thrown.");
+        }
+
+        public InternalException(string message) : this(message, null)
+        {
+        }
+
+        public InternalException(string message, Exception innerException) : base(message, innerException)
+        {
+            NetEventSource.Fail(this, message);
         }
     }
 }


### PR DESCRIPTION
Additionally:

* Exceptions swallowing removed to satisfy CA1031 https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1031
* InternalException refactored to satisfy ca1032 https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1032 (Best practices https://docs.microsoft.com/en-us/dotnet/standard/exceptions/best-practices-for-exceptions#include-three-constructors-in-custom-exception-classes )
* InternalException constructor has been changed to public as class is not marked as sealed.